### PR TITLE
Fix for oversized folding icons

### DIFF
--- a/src/vs/editor/contrib/folding/folding.css
+++ b/src/vs/editor/contrib/folding/folding.css
@@ -8,7 +8,7 @@
 	background-repeat: no-repeat;
 	background-origin: border-box;
 	background-position: calc(50% + 2px) center;
-	background-size: auto calc(100% - 3px);
+	background-size: calc(100% - 3px);
 	opacity: 0;
 	transition: opacity 0.5s;
 }


### PR DESCRIPTION
This adjustment fixes the issue of massive folding icons in the gutter when using a large line height setting.